### PR TITLE
Document bzr as a build dependency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ A repository for osx distributions will be provided soon. But for now, please re
 ### Build it
 
 1. First, make sure you have a `Go <http://http://golang.org/>` language compiler **>= 1.1.2** (*mandatory*) and `git <http://gitscm.org>` installed.
-2. Then, just build and copy the `./bin/trousseau` executable to a system *PATH* location
+2. Make sure you have the following go system dependencies in your `$PATH`: `bzr, svn, hg, git`
+3. Then, just build and copy the `./bin/trousseau` executable to a system *PATH* location
 
 ```bash
 make


### PR DESCRIPTION
While fetching some other code during `make`, I got the following errors:

```
mkdir -p /home/me/repos/trousseau/.gopath/src/github.com/oleiade/
go: missing Bazaar command. See http://golang.org/s/gogetcmd
package code.google.com/p/go.crypto/openpgp
    imports code.google.com/p/go.crypto/openpgp/armor
    imports code.google.com/p/go.crypto/ssh
    imports github.com/codegangsta/cli
    imports github.com/oleiade/reflections
    imports launchpad.net/goamz/aws: exec: "bzr": executable file not found in $PATH
package code.google.com/p/go.crypto/openpgp
    imports code.google.com/p/go.crypto/openpgp/armor
    imports code.google.com/p/go.crypto/ssh
    imports github.com/codegangsta/cli
    imports github.com/oleiade/reflections
    imports launchpad.net/goamz/s3
    imports launchpad.net/goamz/s3
    imports launchpad.net/goamz/s3: cannot find package "launchpad.net/goamz/s3" in any of:
    /usr/lib/go/src/pkg/launchpad.net/goamz/s3 (from $GOROOT)
    /home/me/repos/trousseau/.gopath/src/launchpad.net/goamz/s3 (from $GOPATH)
Makefile:43: recipe for target '/home/me/repos/trousseau/.gopath/src/github.com/oleiade/trousseau' failed
make: *** [/home/me/repos/trousseau/.gopath/src/github.com/oleiade/trousseau] Error 1
```

I am not sure if this problem is archlinux-specific (my linux distro) or if it is a general issue. Either way, a comment in the README.md wouldn't hurt :smiley: 
