### PR TITLE
Fix debian repo info in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ A binary debian repository provides *trousseau* packages for *i386*, *x86_64* an
 Just add the repository to your sources.list:
 
 ```bash
-$ sudo echo "deb http://dl.bintray.com/oleiade/deb /" >> /etc/apt/sources.list
+$ echo "deb http://dl.bintray.com/oleiade/deb /" | sudo tee /etc/apt/sources.list.d/trousseau.list
 ```
 
 And you're ready to go:


### PR DESCRIPTION
The original example will fail because of "Permission denied" (the scope of sudo does not apply
to the stdout append). This variant will work for non-root users.

Also modified it to the best practice of adding custom repositories to their own files within
/etc/apt/sources.list.d/foobar.list
