### PR TITLE
Fix a bug where the key is always empty when set a key.

### DIFF
--- a/trousseau/actions.go
+++ b/trousseau/actions.go
@@ -322,6 +322,8 @@ func SetAction(c *cli.Context) {
 		log.Fatal("Incorrect number of arguments to 'set' command")
 	}
 
+  key = c.Args()[0]
+
 	opts := &crypto.Options{
 		Algorithm:  crypto.GPG_ENCRYPTION,
 		Passphrase: gPasshphrase,


### PR DESCRIPTION
Probably a better way to check if args are set correctly, but Trousseau was broken and I fucking needed it tonight.

Fixes https://github.com/oleiade/trousseau/issues/67
