### PR TITLE
Sort output of "troussau keys" in alphabetical order

### DIFF
--- a/trousseau/store.go
+++ b/trousseau/store.go
@@ -8,6 +8,7 @@ import (
 	openpgp "github.com/oleiade/trousseau/crypto/openpgp"
 	"os"
 	"reflect"
+	"sort"
 )
 
 type Store struct {
@@ -196,6 +197,8 @@ func (ds *DataStore) Keys() ([]string, error) {
 		index++
 	}
 
+	// Sort in alphabetical order
+	sort.Strings(keys)
 	return keys, nil
 }
 


### PR DESCRIPTION
Develop rebase of https://github.com/oleiade/trousseau/pull/82
