### PR TITLE
Fixed homebrew installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ sudo apt-get update && sudo apt-get install trousseau
 If you're using homebrew just proceed to installation using the provided formula:
 
 ```bash
-$ brew install trousseau.rb
+$ brew install https://raw.githubusercontent.com/oleiade/trousseau/master/trousseau.rb
 ```
 
 *Et voila!*


### PR DESCRIPTION
Using a link as install command parameter is easier to install trousseau — it doesn't requires to curl or clone the repository first.
