### PR TITLE
Fixes #138

### DIFF
--- a/cmd/trousseau/commands.go
+++ b/cmd/trousseau/commands.go
@@ -343,6 +343,7 @@ func SetCommand() cli.Command {
 					if err != nil {
 						trousseau.ErrorLogger.Fatal(err)
 					}
+					value = value[:len(value)-1]
 				}
 			}
 


### PR DESCRIPTION
- edited cmd/trousseu/commands.go to not take the delimiting character
  in ReadString()
