### PR TITLE
Fix dependency installation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ all: deps trousseau
 
 deps:
 	@(echo "-> Processing dependencies")
-	# @(go get github.com/kr/godep)
-	# @(godep restore)
+	@(go get github.com/kr/godep)
+	@(godep restore)
 
 trousseau: deps
 	@(echo "-> Compiling trousseau binary")


### PR DESCRIPTION
In the last version bump, the dependency installation in Makefile was commented, it was probably a mistake, undoing...