### PR TITLE
Default to y, if return was pressed on upgrade prompt

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -517,9 +517,11 @@ func UpgradeAction(yes, noBackup bool) error {
 		fmt.Printf("You are about to upgrade trousseau data "+
 			"store %s (version %s) up to version %s. Proceed? [Y/n] ",
 			InferStorePath(), version, TROUSSEAU_VERSION)
-		_, err = fmt.Scanf("%s", &proceed)
-		if err != nil {
-			return err
+		count, _ := fmt.Scanf("%s", &proceed)
+
+		// Default to "y" if return was pressed
+		if count == 0 {
+			proceed = "y"
 		}
 	}
 


### PR DESCRIPTION
When running the upgrade command, the prompt `(Y|n)` indicates that yes is the default answer when pressing return. When return is pressed, the following error message appears

```bash
% trousseau upgrade
You are about to upgrade trousseau data store trousseau.asc (version 0.3.0) up to version 0.3.4. Proceed? [Y/n] 
Error: unexpected newline
```

This fix defaults correctly to "y" if nothing was scanned by checking the `count` return variable instead of `error`.