### PR TITLE
Fix read/write get/set mixup in help command

### DIFF
--- a/cmd/trousseau/commands.go
+++ b/cmd/trousseau/commands.go
@@ -408,7 +408,7 @@ func SetCommand() cli.Command {
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name:  "file, f",
-				Usage: "Write key's value to provided file",
+				Usage: "Read key's value from provided file",
 			},
 		},
 	}
@@ -433,7 +433,7 @@ func GetCommand() cli.Command {
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name:  "file, f",
-				Usage: "Read key's value from provided file",
+				Usage: "Write key's value to provided file",
 			},
 		},
 	}


### PR DESCRIPTION
The `trousseau help get` and `trousseau help set` texts are mixed up.

```
% trousseau help set
NAME:
   set - Set a key value pair in the encrypted data store

USAGE:
   command set [command options] [arguments...]

OPTIONS:
   --file, -f   Write key's value to provided file
```

The option `--file` is actually getting the value from a file when using `set`, and vice versa with `get`.