### PR TITLE
Correct GPG env-var case

### DIFF
--- a/context.go
+++ b/context.go
@@ -60,7 +60,7 @@ func GetPassphrase() (passphrase string) {
 
 	// if passphrase was enither found in the environment nor
 	// system keyring manager try to fetch it from gpg-agent
-	if os.Getenv("gpg_agent_info") != "" {
+	if os.Getenv("GPG_AGENT_INFO") != "" {
 		passphrase, err = getGpgPassphrase(os.Getenv(ENV_MASTER_GPG_ID_KEY))
 	}
 


### PR DESCRIPTION
It must be upper case as in `gpgagent.go`.