### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ $ trousseau get abc
 Ultimately, you can pass you gpg passphrase through the command line global option:
 
 ```bash
-$ trousseau --passhphrase mysupperdupperpassphrase get abc
+$ trousseau --passphrase mysupperdupperpassphrase get abc
 ```
 
 #### Environment


### PR DESCRIPTION
The correct option is `passphrase` and not `passhphrase` :)
